### PR TITLE
fix(package.json): enable manual mode, workaround for remix 2.0.1 hmr

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "remix dev -c \"npm run dev:serve\"",
+    "dev": "remix dev --manual -c \"npm run dev:serve\"",
     "dev:serve": "binode --require ./mocks -- @remix-run/serve:remix-serve ./build/index.js",
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",


### PR DESCRIPTION
### Description
With the introduction of remix minor version `2.0.1`. Hot reloading appears to stop working. Adding the manual flag fixes the issue for now, there will likely be an incoming patch that addresses this issue in the near future.
- [Github issue](https://github.com/remix-run/remix/issues/7466#issue-1901112312)


## Sign off

- [x] Code conforms to the [Frontend Coding Style Guide](https://www.notion.so/paystack/Frontend-Coding-Style-Guide-5918f0348a514e57a742727c164ddb6b)
- [ ] Added test(s)
- [ ] Merged this branch into `dev`
- [x] Added sufficient inline comments and/or added to DEV_DOCS.md if needed
- [x] Can be safely merged to master and deployed to production pending pr approval
